### PR TITLE
feat: Add automatic token refresh handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ npm run build
    # Move your downloaded OAuth JSON file to the credentials directory as gcp-oauth.keys.json
    ```
 
-2. Run the authentication command:
+2. Run the authentication command (only needed once for initial setup):
    ```bash
    node dist/index.js auth
    ```
 
 3. Complete the OAuth flow in your browser
 4. Credentials will be saved in `credentials/.gdrive-server-credentials.json`
+5. After initial authentication, tokens will be automatically refreshed when needed
 
 ## 🔧 Usage
 
@@ -184,6 +185,7 @@ Replace `path/to/gdrive-mcp-server` with the actual path to your installation di
 - OAuth credentials and tokens are excluded from version control
 - Read-only access to Google Drive
 - Secure OAuth 2.0 authentication flow
+- Automatic and secure token refresh handling
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## What does this PR do?

This PR adds automatic token refresh handling to improve the reliability of the Google Drive MCP server.

## Changes
- Added refreshAccessToken function to handle token refresh
- Wrapped Google Drive API calls with token refresh logic
- Implemented automatic token refresh when it expires
- Added functionality to save refreshed tokens to credentials file
- Updated README with token refresh information

## Why is this change necessary?
Previously, when the access token expired, the server would fail with authentication errors. This change makes the server more robust by automatically handling token expiration and refresh.

## How was this tested?
- Tested token refresh flow by forcing token expiration
- Verified that API calls continue to work after token refresh
- Confirmed that refreshed tokens are properly saved to credentials file

## Additional Notes
This change is backwards compatible and requires no changes to existing configuration files.